### PR TITLE
feat: 채팅방 종료 API 추가 및 종료시 포트폴리오 상태 COMPLETED 로 변경 처리

### DIFF
--- a/src/main/java/com/kkks/pofolling/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/kkks/pofolling/chat/controller/ChatRoomController.java
@@ -4,6 +4,7 @@ import com.kkks.pofolling.chat.dto.ChatMessageRequestDTO;
 import com.kkks.pofolling.chat.dto.ChatRoomRequestDTO;
 import com.kkks.pofolling.chat.service.ChatMessageService;
 import com.kkks.pofolling.chat.service.ChatRoomService;
+import com.kkks.pofolling.chat.service.ChatRoomServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
+    private final ChatRoomServiceImpl chatRoomServiceImpl;
 
     // 채팅방 생성
     @PostMapping
@@ -28,6 +30,14 @@ public class ChatRoomController {
     public ResponseEntity<?> findChatRooms(@PathVariable Long userId) {
         return ResponseEntity.ok(chatRoomService.findAllChatRoomsByUserId(userId));
     }
+
+    // 채팅방 종료
+    @PatchMapping("/{chatRoomId}/deactivate")
+    public ResponseEntity<String> deactivateChatRoom (@PathVariable Long chatRoomId) {
+        chatRoomService.deactivateChatRoom(chatRoomId);
+        return ResponseEntity.ok("첨삭종료");
+    }
+
 
 
 }

--- a/src/main/java/com/kkks/pofolling/chat/service/ChatMessageServiceImpl.java
+++ b/src/main/java/com/kkks/pofolling/chat/service/ChatMessageServiceImpl.java
@@ -25,8 +25,6 @@ public class ChatMessageServiceImpl implements ChatMessageService {
     private final UserRepository userRepository;
 
     // 채팅 메세지 저장
-    // 📁 ChatMessageServiceImpl.java
-
     @Override
     @Transactional
     public ChatMessageResponseDTO saveNewChatMessage(Long chatRoomId, Long senderId, String message) {
@@ -57,7 +55,6 @@ public class ChatMessageServiceImpl implements ChatMessageService {
                 .sentAt(saved.getSentAt())
                 .build();
     }
-
 
     // 채팅방의 모든 메세지 조회
     @Override

--- a/src/main/java/com/kkks/pofolling/chat/service/ChatRoomService.java
+++ b/src/main/java/com/kkks/pofolling/chat/service/ChatRoomService.java
@@ -10,4 +10,5 @@ public interface ChatRoomService {
     ChatRoomResponseDTO createChatRoom(Long mentorId, Long portfolioId);
     ChatRoom createChatRoomIfNotExists(Long mentorId, Long menteeId, Long portfolioId);
     List<ChatRoomResponseDTO> findAllChatRoomsByUserId(Long userId);
+    void deactivateChatRoom(Long chatRoomId);
 }

--- a/src/main/java/com/kkks/pofolling/chat/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/kkks/pofolling/chat/service/ChatRoomServiceImpl.java
@@ -84,6 +84,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
                 .portfolio(portfolio)
                 .mentor(mentor)
                 .mentee(mentee)
+                .isActive(true)
                 .build();
 
         return chatRoomRepository.save(newRoom);
@@ -131,8 +132,10 @@ public class ChatRoomServiceImpl implements ChatRoomService {
                 .orElseThrow(() -> new BusinessException(ExceptionCode.CHATROOM_NOT_FOUND));
 
         chatRoom.deactivate();
-    }
 
+        Portfolio portfolio = chatRoom.getPortfolio();
+        portfolio.updateStatus(PortfolioStatus.COMPLETED);
+    }
 
     // 공통 DTO 변환
     private ChatRoomResponseDTO convertToDTO(ChatRoom room) {


### PR DESCRIPTION
- ChatRoomController에 채팅방 종료용 PATCH API 추가 (/chat/room/{chatRoomId}/deactivate)
- ChatRoomService에 deactivateChatRoom 메서드 구현
- 채팅방 종료 시 chat_room.is_active = false 처리
- 연결된 포트폴리오 상태를 COMPLETED로 변경 처리
