### PR TITLE
Feature26

### DIFF
--- a/src/main/java/com/kkks/pofolling/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/kkks/pofolling/chat/controller/ChatRoomController.java
@@ -38,6 +38,4 @@ public class ChatRoomController {
         return ResponseEntity.ok("첨삭종료");
     }
 
-
-
 }

--- a/src/main/java/com/kkks/pofolling/chat/entity/ChatRoom.java
+++ b/src/main/java/com/kkks/pofolling/chat/entity/ChatRoom.java
@@ -44,6 +44,10 @@ public class ChatRoom {
     @Column(name = "is_active")
     private boolean isActive = true;
 
+    public void activate() {
+        this.isActive = true;
+    }
+
     public void deactivate() {
         this.isActive = false;
     }

--- a/src/main/java/com/kkks/pofolling/chat/service/ChatMessageServiceImpl.java
+++ b/src/main/java/com/kkks/pofolling/chat/service/ChatMessageServiceImpl.java
@@ -32,7 +32,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
                 .orElseThrow(() -> new BusinessException(ExceptionCode.CHATROOM_NOT_FOUND));
 
         if (!chatRoom.isActive()) {
-            throw new BusinessException(ExceptionCode.CHATROOM_CLOSED);  // 커스텀 예외 코드 추가 필요
+            throw new BusinessException(ExceptionCode.CHATROOM_CLOSED);
         }
 
         User sender = userRepository.findById(senderId)
@@ -58,6 +58,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
 
     // 채팅방의 모든 메세지 조회
     @Override
+    @Transactional(readOnly = true)
     public List<ChatMessageResponseDTO> findAllMessagesByChatRoomId(Long chatRoomId) {
         List<ChatMessage> messages = chatMessageRepository.findByChatRoom_ChatRoomIdOrderBySentAt(chatRoomId);
 

--- a/src/main/java/com/kkks/pofolling/chat/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/kkks/pofolling/chat/service/ChatRoomServiceImpl.java
@@ -70,9 +70,17 @@ public class ChatRoomServiceImpl implements ChatRoomService {
                 .findByMentor_UserIdAndMentee_UserIdAndPortfolio_PortfolioId(mentorId, menteeId, portfolioId);
 
         if (existingRoom.isPresent()) {
-            return existingRoom.get();
+            ChatRoom room = existingRoom.get();
+
+            // 비활성화 상태면 다시 활성화
+            if (!room.isActive()) {
+                room.activate(); // 또는 room.setIsActive(true);
+            }
+
+            return room;
         }
 
+        // 기존 방 없음 → 새로 생성
         Portfolio portfolio = portfolioRepository.findById(portfolioId)
                 .orElseThrow(() -> new BusinessException(ExceptionCode.PORTFOLIO_NOT_FOUND));
         User mentor = userRepository.findById(mentorId)
@@ -89,6 +97,7 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
         return chatRoomRepository.save(newRoom);
     }
+
 
     // 채팅방 목록 조회
     @Override


### PR DESCRIPTION
1. 기존 portfolio_id unique 제약 제거 후 복합 unique 제약 조건 추가
- portfolio_id 단일 unique 제약 제거 (첨삭 재요청/다른 멘토 수락 허용 위해)
- mentor_id, mentee_id, portfolio_id 세 컬럼 기준으로 유니크하도록 설정
- 하나의 포트폴리오에 대해 여러 멘토와 채팅 가능하게 구조 수정

2. 동일 멘토-멘티는 기존 채팅방 재사용하도록 로직 수정
- 기존 포트폴리오에 대해 멘토-멘티 조합이 같을 경우 기존 ChatRoom isActive = true로 복구
- 조합이 다르면 새 ChatRoom 생성
- ChatRoom 엔터티에 activate() 메서드 추가
